### PR TITLE
#g16a6n Service injection container - PSR-11 compatible

### DIFF
--- a/src/AGerault/Contracts/Services/ServiceContainerInterface.php
+++ b/src/AGerault/Contracts/Services/ServiceContainerInterface.php
@@ -13,4 +13,17 @@ interface ServiceContainerInterface extends ContainerInterface
      * @param string $target
      */
     public function addAlias(string $alias, string $target): void;
+
+    /**
+     * Register a service definition
+     *
+     * @param string $id
+     */
+    public function register(string $id): void;
+
+    /**
+     * @param string $id
+     * @return ServiceDefinitionInterface
+     */
+    public function getDefinition(string $id): ServiceDefinitionInterface;
 }

--- a/src/AGerault/Contracts/Services/ServiceContainerInterface.php
+++ b/src/AGerault/Contracts/Services/ServiceContainerInterface.php
@@ -26,4 +26,18 @@ interface ServiceContainerInterface extends ContainerInterface
      * @return ServiceDefinitionInterface
      */
     public function getDefinition(string $id): ServiceDefinitionInterface;
+
+    /**
+     * Register a new parameter
+     *
+     * @param string $id
+     * @param mixed $value
+     */
+    public function addParameter(string $id, mixed $value): void;
+
+    /**
+     * @param string $id
+     * @return mixed
+     */
+    public function getParameter(string $id): mixed;
 }

--- a/src/AGerault/Contracts/Services/ServiceContainerInterface.php
+++ b/src/AGerault/Contracts/Services/ServiceContainerInterface.php
@@ -6,4 +6,11 @@ use Psr\Container\ContainerInterface;
 
 interface ServiceContainerInterface extends ContainerInterface
 {
+    /**
+     * Register an alias (say which class to instantiate for a given interface)
+     *
+     * @param string $alias
+     * @param string $target
+     */
+    public function addAlias(string $alias, string $target): void;
 }

--- a/src/AGerault/Contracts/Services/ServiceContainerInterface.php
+++ b/src/AGerault/Contracts/Services/ServiceContainerInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace AGerault\Framework\Contracts\Services;
+
+use Psr\Container\ContainerInterface;
+
+interface ServiceContainerInterface extends ContainerInterface
+{
+}

--- a/src/AGerault/Contracts/Services/ServiceDefinitionInterface.php
+++ b/src/AGerault/Contracts/Services/ServiceDefinitionInterface.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace AGerault\Framework\Contracts\Services;
+
+interface ServiceDefinitionInterface
+{
+    /**
+     * Define if the service should be instanced once or each time it is called
+     *
+     * @return bool
+     */
+    public function isShared(): bool;
+
+    /**
+     * Give the alias of the service
+     *
+     * @return array
+     */
+    public function aliases(): array;
+
+    /**
+     * Give the definitions this depends on
+     *
+     * @return array<ServiceDefinitionInterface>
+     */
+    public function dependencies(): array;
+
+    /**
+     * Make the service be instantiated every time
+     */
+    public function makeNotShared(): void;
+
+    /**
+     * Make the service be instantiated only once (default)
+     */
+    public function makeShared(): void;
+}

--- a/src/AGerault/Contracts/Services/ServiceNotFoundExceptionInterface.php
+++ b/src/AGerault/Contracts/Services/ServiceNotFoundExceptionInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace AGerault\Framework\Contracts\Services;
+
+use Psr\Container\NotFoundExceptionInterface;
+
+interface ServiceNotFoundExceptionInterface extends NotFoundExceptionInterface
+{
+
+}

--- a/src/AGerault/Contracts/Session/SessionInterface.php
+++ b/src/AGerault/Contracts/Session/SessionInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace AGerault\Framework\Contracts\Session;
+
+interface SessionInterface
+{
+
+}

--- a/src/AGerault/Services/Exceptions/ContainerException.php
+++ b/src/AGerault/Services/Exceptions/ContainerException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace AGerault\Framework\Services\Exceptions;
+
+use Exception;
+use Psr\Container\ContainerExceptionInterface;
+
+class ContainerException extends Exception implements ContainerExceptionInterface
+{
+}

--- a/src/AGerault/Services/Exceptions/ServiceNotFoundException.php
+++ b/src/AGerault/Services/Exceptions/ServiceNotFoundException.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace AGerault\Framework\Services\Exceptions;
+
+use AGerault\Framework\Contracts\Services\ServiceNotFoundExceptionInterface;
+use JetBrains\PhpStorm\Pure;
+use Throwable;
+
+class ServiceNotFoundException extends \Exception implements ServiceNotFoundExceptionInterface
+{
+    #[Pure] public function __construct(string $serviceId = "", $code = 0, Throwable $previous = null)
+    {
+        parent::__construct(
+            "Cannot find the service identified by " . $serviceId,
+            $code,
+            $previous
+        );
+    }
+}

--- a/src/AGerault/Services/Exceptions/ServiceNotFoundException.php
+++ b/src/AGerault/Services/Exceptions/ServiceNotFoundException.php
@@ -8,12 +8,9 @@ use Throwable;
 
 class ServiceNotFoundException extends \Exception implements ServiceNotFoundExceptionInterface
 {
-    #[Pure] public function __construct(string $serviceId = "", $code = 0, Throwable $previous = null)
+    #[Pure]
+    public function __construct(string $serviceId = "")
     {
-        parent::__construct(
-            "Cannot find the service identified by " . $serviceId,
-            $code,
-            $previous
-        );
+        parent::__construct("Cannot find the service identified by " . $serviceId);
     }
 }

--- a/src/AGerault/Services/ServiceContainer.php
+++ b/src/AGerault/Services/ServiceContainer.php
@@ -5,7 +5,6 @@ namespace AGerault\Framework\Services;
 use AGerault\Framework\Contracts\Services\ServiceContainerInterface;
 use AGerault\Framework\Contracts\Services\ServiceDefinitionInterface;
 use AGerault\Framework\Services\Exceptions\ContainerException;
-use AGerault\Framework\Services\Exceptions\ServiceNotFoundException;
 use JetBrains\PhpStorm\Pure;
 use ReflectionClass;
 use ReflectionException;
@@ -44,7 +43,6 @@ class ServiceContainer implements ServiceContainerInterface
      * @param string $id
      *
      * @return mixed
-     * @throws ServiceNotFoundException
      * @throws ReflectionException
      * @throws ContainerException
      */
@@ -69,9 +67,8 @@ class ServiceContainer implements ServiceContainerInterface
     }
 
     #[Pure]
-    public function has(
-        string $id
-    ): bool {
+    public function has(string $id): bool
+    {
         return isset($this->instances[$id]);
     }
 
@@ -115,6 +112,10 @@ class ServiceContainer implements ServiceContainerInterface
      */
     public function register(string $id): void
     {
+        if (!class_exists($id) && !interface_exists($id)) {
+            throw new ContainerException("This class does not exist");
+        }
+
         $reflectionClass = new ReflectionClass($id);
 
         if ($reflectionClass->isInterface()) {
@@ -158,13 +159,17 @@ class ServiceContainer implements ServiceContainerInterface
     }
 
     /**
-     * @param $id
+     * @param string $id
      * @return object
      * @throws ContainerException
      * @throws ReflectionException
      */
-    private function resolve($id): object
+    private function resolve(string $id): object
     {
+        if (!class_exists($id) && !interface_exists($id)) {
+            throw new ContainerException("This class does not exist");
+        }
+
         $reflectionClass = new ReflectionClass($id);
 
         // If we are handling an interface, we have to resolve to its class

--- a/src/AGerault/Services/ServiceContainer.php
+++ b/src/AGerault/Services/ServiceContainer.php
@@ -15,9 +15,9 @@ use ReflectionUnionType;
  * Implements PSR-11 ContainerInterface for a service container
  * See: https://www.php-fig.org/psr/psr-11/
  *
- * This class is a container for services. Its services array is
- * filled at the construction and then never modified: it is
- * immutable. Thus it avoid side effects.
+ * This class is a container for services. Its responsibility
+ * is to instantiate a service and its dependencies using
+ * reflection and recursiveness.
  *
  * @package AGerault\Framework\Services
  * @author Alexandre Gérault

--- a/src/AGerault/Services/ServiceContainer.php
+++ b/src/AGerault/Services/ServiceContainer.php
@@ -80,7 +80,8 @@ class ServiceContainer implements ServiceContainerInterface
         return $this->instances[$id];
     }
 
-    #[Pure] public function has(string $id): bool
+    #[Pure]
+    public function has(string $id): bool
     {
         return isset($this->instances[$id]);
     }

--- a/src/AGerault/Services/ServiceContainer.php
+++ b/src/AGerault/Services/ServiceContainer.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace AGerault\Framework\Services;
+
+use AGerault\Framework\Contracts\Services\ServiceContainerInterface;
+use AGerault\Framework\Services\Exceptions\ContainerException;
+use AGerault\Framework\Services\Exceptions\ServiceNotFoundException;
+use JetBrains\PhpStorm\Pure;
+use ReflectionClass;
+use ReflectionException;
+use ReflectionNamedType;
+use ReflectionUnionType;
+
+/**
+ * Implements PSR-11 ContainerInterface for a service container
+ * See: https://www.php-fig.org/psr/psr-11/
+ *
+ * This class is a container for services. Its services array is
+ * filled at the construction and then never modified: it is
+ * immutable. Thus it avoid side effects.
+ *
+ * @package AGerault\Framework\Services
+ * @author Alexandre Gérault
+ */
+class ServiceContainer implements ServiceContainerInterface
+{
+    /**
+     * @var  array<string, string>
+     */
+    protected array $aliases = [];
+
+    /**
+     * @var array<string, mixed>
+     */
+    protected array $instances = [];
+
+    /**
+     * @param string $id
+     *
+     * @return mixed
+     * @throws ServiceNotFoundException
+     * @throws ReflectionException
+     * @throws ContainerException
+     */
+    public function get(string $id): mixed
+    {
+        if (! class_exists($id)) {
+            throw new ContainerException();
+        }
+
+        // If we have no instances of this id, let's build one
+        if (! $this->has($id)) {
+            $reflectionClass = new ReflectionClass($id);
+
+            // If the constructor of the class is null, no dependencies are required
+            // Else we need to build each dependency
+            if ($reflectionClass->getConstructor() === null) {
+                $this->instances[$id] = $reflectionClass->newInstance();
+            } else {
+                $constructor = $reflectionClass->getConstructor();
+                $parameters  = $constructor->getParameters();
+
+                $this->instances[$id] = $reflectionClass->newInstanceArgs(
+                    array_map(
+                        function ($param) {
+                            $paramType = $param->getType();
+
+                            if ($paramType instanceof ReflectionNamedType) {
+                                return $this->get($paramType->getName());
+                            } else {
+                                throw new ContainerException();
+                            }
+                        },
+                        $parameters
+                    )
+                );
+            }
+        }
+
+        return $this->instances[$id];
+    }
+
+    #[Pure] public function has(string $id): bool
+    {
+        return isset($this->instances[$id]);
+    }
+}

--- a/src/AGerault/Services/ServiceDefinition.php
+++ b/src/AGerault/Services/ServiceDefinition.php
@@ -23,7 +23,7 @@ class ServiceDefinition implements ServiceDefinitionInterface
     /**
      * The class' interface name
      *
-     * @var array
+     * @var array<string>
      */
     protected array $aliases = [];
 
@@ -38,7 +38,7 @@ class ServiceDefinition implements ServiceDefinitionInterface
      * ServiceDefinition constructor.
      * @param string $id
      * @param bool $shared
-     * @param array $aliases
+     * @param array<string> $aliases
      * @param ServiceDefinitionInterface[] $dependencies
      */
     public function __construct(string $id, bool $shared = true, array $aliases = [], array $dependencies = [])
@@ -54,6 +54,9 @@ class ServiceDefinition implements ServiceDefinitionInterface
         return $this->shared;
     }
 
+    /**
+     * @return array<string>
+     */
     public function aliases(): array
     {
         return $this->aliases;

--- a/src/AGerault/Services/ServiceDefinition.php
+++ b/src/AGerault/Services/ServiceDefinition.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace AGerault\Framework\Services;
+
+use AGerault\Framework\Contracts\Services\ServiceDefinitionInterface;
+
+class ServiceDefinition implements ServiceDefinitionInterface
+{
+    /**
+     * The service's unique identifier
+     *
+     * @var string
+     */
+    protected string $id;
+
+    /**
+     * Defines whether the service should be a singleton
+     *
+     * @var bool
+     */
+    protected bool $shared;
+
+    /**
+     * The class' interface name
+     *
+     * @var array
+     */
+    protected array $aliases = [];
+
+    /**
+     * The definitions this depends on
+     *
+     * @var array<ServiceDefinitionInterface>
+     */
+    protected array $dependencies;
+
+    /**
+     * ServiceDefinition constructor.
+     * @param string $id
+     * @param bool $shared
+     * @param array $aliases
+     * @param ServiceDefinitionInterface[] $dependencies
+     */
+    public function __construct(string $id, bool $shared = true, array $aliases = [], array $dependencies = [])
+    {
+        $this->id = $id;
+        $this->shared = $shared;
+        $this->aliases = $aliases;
+        $this->dependencies = $dependencies;
+    }
+
+    public function isShared(): bool
+    {
+        return $this->shared;
+    }
+
+    public function aliases(): array
+    {
+        return $this->aliases;
+    }
+
+    public function dependencies(): array
+    {
+        return $this->dependencies;
+    }
+
+    public function makeNotShared(): void
+    {
+        $this->shared = false;
+    }
+
+    public function makeShared(): void
+    {
+        $this->shared = true;
+    }
+}

--- a/tests/Fixtures/Services/BarService.php
+++ b/tests/Fixtures/Services/BarService.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace Test\Fixtures\Services;
-
 
 class BarService
 {

--- a/tests/Fixtures/Services/BarService.php
+++ b/tests/Fixtures/Services/BarService.php
@@ -1,0 +1,15 @@
+<?php
+
+
+namespace Test\Fixtures\Services;
+
+
+class BarService
+{
+    protected FooService $foo;
+
+    public function __construct(FooService $foo)
+    {
+        $this->foo = $foo;
+    }
+}

--- a/tests/Fixtures/Services/FooAltService.php
+++ b/tests/Fixtures/Services/FooAltService.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace Test\Fixtures\Services;
-
 
 class FooAltService
 {

--- a/tests/Fixtures/Services/FooAltService.php
+++ b/tests/Fixtures/Services/FooAltService.php
@@ -1,0 +1,9 @@
+<?php
+
+
+namespace Test\Fixtures\Services;
+
+
+class FooAltService
+{
+}

--- a/tests/Fixtures/Services/FooService.php
+++ b/tests/Fixtures/Services/FooService.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Test\Fixtures\Services;
+
+class FooService
+{
+}

--- a/tests/Fixtures/Services/NotSharedService.php
+++ b/tests/Fixtures/Services/NotSharedService.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Test\Fixtures\Services;
+
+class NotSharedService
+{
+}

--- a/tests/Fixtures/Services/RandomService.php
+++ b/tests/Fixtures/Services/RandomService.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Test\Fixtures\Services;
+
+class RandomService implements RandomServiceInterface
+{
+}

--- a/tests/Fixtures/Services/RandomServiceInterface.php
+++ b/tests/Fixtures/Services/RandomServiceInterface.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace Test\Fixtures\Services;
-
 
 interface RandomServiceInterface
 {

--- a/tests/Fixtures/Services/RandomServiceInterface.php
+++ b/tests/Fixtures/Services/RandomServiceInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+
+namespace Test\Fixtures\Services;
+
+
+interface RandomServiceInterface
+{
+
+}

--- a/tests/Fixtures/Services/ServiceWithParameters.php
+++ b/tests/Fixtures/Services/ServiceWithParameters.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Test\Fixtures\Services;
+
+class ServiceWithParameters
+{
+    protected string $parameter;
+
+    /**
+     * ServiceWithParameters constructor.
+     * @param string $parameter
+     */
+    public function __construct(string $parameter)
+    {
+        $this->parameter = $parameter;
+    }
+
+    public function getParameter(): string
+    {
+        return $this->parameter;
+    }
+}

--- a/tests/Fixtures/Services/UnionTypeServiceInjection.php
+++ b/tests/Fixtures/Services/UnionTypeServiceInjection.php
@@ -1,19 +1,17 @@
 <?php
 
-
 namespace Test\Fixtures\Services;
-
 
 class UnionTypeServiceInjection
 {
-    protected FooService|FooAltService $service;
+    protected FooService | FooAltService $service;
 
     /**
      * UnionTypeServiceInjection constructor.
      *
      * @param FooAltService|FooService $service
      */
-    public function __construct(FooService|FooAltService $service)
+    public function __construct(FooService | FooAltService $service)
     {
         $this->service = $service;
     }

--- a/tests/Fixtures/Services/UnionTypeServiceInjection.php
+++ b/tests/Fixtures/Services/UnionTypeServiceInjection.php
@@ -1,0 +1,20 @@
+<?php
+
+
+namespace Test\Fixtures\Services;
+
+
+class UnionTypeServiceInjection
+{
+    protected FooService|FooAltService $service;
+
+    /**
+     * UnionTypeServiceInjection constructor.
+     *
+     * @param FooAltService|FooService $service
+     */
+    public function __construct(FooService|FooAltService $service)
+    {
+        $this->service = $service;
+    }
+}

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+|--------------------------------------------------------------------------
+| Test Case
+|--------------------------------------------------------------------------
+|
+| The closure you provide to your test functions is always bound to a specific PHPUnit test
+| case class. By default, that class is "PHPUnit\Framework\TestCase". Of course, you may
+| need to change it using the "uses()" function to bind a different classes or traits.
+|
+*/
+
+// uses(Tests\TestCase::class)->in('Feature');
+
+/*
+|--------------------------------------------------------------------------
+| Expectations
+|--------------------------------------------------------------------------
+|
+| When you're writing tests, you often need to check that values meet certain conditions. The
+| "expect()" function gives you access to a set of "expectations" methods that you can use
+| to assert different things. Of course, you may extend the Expectation API at any time.
+|
+*/
+
+expect()->extend('toBeOne', function () {
+    return $this->toBe(1);
+});
+
+/*
+|--------------------------------------------------------------------------
+| Functions
+|--------------------------------------------------------------------------
+|
+| While Pest is very powerful out-of-the-box, you may have some testing code specific to your
+| project that you don't want to repeat in every file. Here you can also expose helpers as
+| global functions to help you to reduce the number of lines of code in your test files.
+|
+*/
+
+function something()
+{
+    // ..
+}

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -11,8 +11,6 @@
 |
 */
 
-// uses(Tests\TestCase::class)->in('Feature');
-
 /*
 |--------------------------------------------------------------------------
 | Expectations
@@ -24,10 +22,6 @@
 |
 */
 
-expect()->extend('toBeOne', function () {
-    return $this->toBe(1);
-});
-
 /*
 |--------------------------------------------------------------------------
 | Functions
@@ -38,8 +32,3 @@ expect()->extend('toBeOne', function () {
 | global functions to help you to reduce the number of lines of code in your test files.
 |
 */
-
-function something()
-{
-    // ..
-}

--- a/tests/Unit/Services/ServiceContainerTest.php
+++ b/tests/Unit/Services/ServiceContainerTest.php
@@ -3,6 +3,8 @@
 use AGerault\Framework\Services\ServiceContainer;
 use Test\Fixtures\Services\BarService;
 use Test\Fixtures\Services\FooService;
+use Test\Fixtures\Services\RandomService;
+use Test\Fixtures\Services\RandomServiceInterface;
 use Test\Fixtures\Services\UnionTypeServiceInjection;
 
 it(
@@ -24,7 +26,7 @@ it(
 );
 
 it(
-    'checks that it can build classes depending on another service',
+    'can build classes depending on another service',
     function () {
         $container = new ServiceContainer();
 
@@ -41,3 +43,16 @@ it(
         expect($container->get(UnionTypeServiceInjection::class))->toBeInstanceOf(UnionTypeServiceInjection::class);
     }
 )->throws(Exception::class);
+
+it(
+    'can inject interfaces implementation',
+    function () {
+        $container = new ServiceContainer();
+
+        $container->addAlias(RandomServiceInterface::class, RandomService::class);
+
+        $container->get(RandomServiceInterface::class);
+
+        expect($container->get(RandomServiceInterface::class))->toBeInstanceOf(RandomServiceInterface::class);
+    }
+);

--- a/tests/Unit/Services/ServiceContainerTest.php
+++ b/tests/Unit/Services/ServiceContainerTest.php
@@ -3,6 +3,7 @@
 use AGerault\Framework\Services\ServiceContainer;
 use Test\Fixtures\Services\BarService;
 use Test\Fixtures\Services\FooService;
+use Test\Fixtures\Services\NotSharedService;
 use Test\Fixtures\Services\RandomService;
 use Test\Fixtures\Services\RandomServiceInterface;
 use Test\Fixtures\Services\UnionTypeServiceInjection;
@@ -17,7 +18,7 @@ it(
 );
 
 it(
-    'checks that returned services have the same instance',
+    'should return the same service instance',
     function () {
         $container = new ServiceContainer();
 
@@ -26,7 +27,7 @@ it(
 );
 
 it(
-    'can build classes depending on another service',
+    'should build classes and its dependencies',
     function () {
         $container = new ServiceContainer();
 
@@ -36,7 +37,7 @@ it(
 );
 
 it(
-    'checks that it throws an exception when trying to use an union type in service constructor',
+    'should throws an exception when trying to use an union type in service constructor',
     function () {
         $container = new ServiceContainer();
 
@@ -45,7 +46,7 @@ it(
 )->throws(Exception::class);
 
 it(
-    'can inject interfaces implementation',
+    'should be able to inject interfaces implementation',
     function () {
         $container = new ServiceContainer();
 
@@ -54,5 +55,18 @@ it(
         $container->get(RandomServiceInterface::class);
 
         expect($container->get(RandomServiceInterface::class))->toBeInstanceOf(RandomServiceInterface::class);
+    }
+);
+
+it(
+    'should return a different service instance if it is not shared',
+    function () {
+        $container = new ServiceContainer();
+
+        $container->getDefinition(NotSharedService::class)->makeNotShared();
+        $instanceA = $container->get(NotSharedService::class);
+        $instanceB = $container->get(NotSharedService::class);
+
+        expect(spl_object_id($instanceA))->not()->toBe(spl_object_id($instanceB));
     }
 );

--- a/tests/Unit/Services/ServiceContainerTest.php
+++ b/tests/Unit/Services/ServiceContainerTest.php
@@ -1,0 +1,43 @@
+<?php
+
+use AGerault\Framework\Services\ServiceContainer;
+use Test\Fixtures\Services\BarService;
+use Test\Fixtures\Services\FooService;
+use Test\Fixtures\Services\UnionTypeServiceInjection;
+
+it(
+    'checks the type of returned class by the container',
+    function () {
+        $container = new ServiceContainer();
+
+        expect($container->get(FooService::class))->toBeInstanceOf(FooService::class);
+    }
+);
+
+it(
+    'checks that returned services have the same instance',
+    function () {
+        $container = new ServiceContainer();
+
+        expect($container->get(FooService::class))->toBe($container->get(FooService::class));
+    }
+);
+
+it(
+    'checks that it can build classes depending on another service',
+    function () {
+        $container = new ServiceContainer();
+
+        expect($container->get(BarService::class))->toBeInstanceOf(BarService::class);
+        expect($container->has(FooService::class))->toBeTrue();
+    }
+);
+
+it(
+    'checks that it throws an exception when trying to use an union type in service constructor',
+    function () {
+        $container = new ServiceContainer();
+
+        expect($container->get(UnionTypeServiceInjection::class))->toBeInstanceOf(UnionTypeServiceInjection::class);
+    }
+)->throws(Exception::class);

--- a/tests/Unit/Services/ServiceContainerTest.php
+++ b/tests/Unit/Services/ServiceContainerTest.php
@@ -6,6 +6,7 @@ use Test\Fixtures\Services\FooService;
 use Test\Fixtures\Services\NotSharedService;
 use Test\Fixtures\Services\RandomService;
 use Test\Fixtures\Services\RandomServiceInterface;
+use Test\Fixtures\Services\ServiceWithParameters;
 use Test\Fixtures\Services\UnionTypeServiceInjection;
 
 it(
@@ -68,5 +69,20 @@ it(
         $instanceB = $container->get(NotSharedService::class);
 
         expect(spl_object_id($instanceA))->not()->toBe(spl_object_id($instanceB));
+    }
+);
+
+it(
+    'should be able to build a service depending on parameters',
+    function () {
+        $container = new ServiceContainer();
+
+        $container->addParameter('parameter', 'Parameter');
+        /**
+         * @var ServiceWithParameters $service
+         */
+        $service = $container->get(ServiceWithParameters::class);
+
+        expect($service->getParameter())->toBe('Parameter');
     }
 );


### PR DESCRIPTION
Handles construction of services without constructor and services with the injection of service classes. Next is to handle the dependency inversion principle (i.e. handle interfaces with aliases).

![dependency_injection_container_class](https://user-images.githubusercontent.com/3494871/111961532-7800c580-8af1-11eb-959b-2bae79c9bcf8.png)
